### PR TITLE
Do not replace existing integrations by default ones

### DIFF
--- a/src/DI/SentryExtension.php
+++ b/src/DI/SentryExtension.php
@@ -116,23 +116,27 @@ class SentryExtension extends CompilerExtension
 		$client = $config->client ?? [];
 
 		if ($config->integrations) {
-			$client['integrations'] = [
-				// Sentry
-				new Statement(EnvironmentIntegration::class),
-				new Statement(ErrorListenerIntegration::class),
-				new Statement(ExceptionListenerIntegration::class),
-				new Statement(FatalErrorListenerIntegration::class),
-				new Statement(FrameContextifierIntegration::class, [null]),
-				new Statement(ModulesIntegration::class),
-				new Statement(RequestIntegration::class, [null]),
-				new Statement(TransactionIntegration::class),
-				// Nette
-				new Statement(NetteApplicationIntegration::class),
-				new Statement(NetteHttpIntegration::class),
-				new Statement(NetteSecurityIntegration::class),
-				new Statement(NetteSessionIntegration::class),
-				new Statement(ExtraIntegration::class, [[]]),
-			];
+			$client['integrations'] ??= [];
+			$client['integrations'] = array_merge(
+				$client['integrations'],
+				[
+					// Sentry
+					new Statement(EnvironmentIntegration::class),
+					new Statement(ErrorListenerIntegration::class),
+					new Statement(ExceptionListenerIntegration::class),
+					new Statement(FatalErrorListenerIntegration::class),
+					new Statement(FrameContextifierIntegration::class, [null]),
+					new Statement(ModulesIntegration::class),
+					new Statement(RequestIntegration::class, [null]),
+					new Statement(TransactionIntegration::class),
+					// Nette
+					new Statement(NetteApplicationIntegration::class),
+					new Statement(NetteHttpIntegration::class),
+					new Statement(NetteSecurityIntegration::class),
+					new Statement(NetteSessionIntegration::class),
+					new Statement(ExtraIntegration::class, [[]]),
+				]
+			);
 		}
 
 		$initialize = $class->getMethod('initialize');


### PR DESCRIPTION
Now when I register my own integration in the config such as:
```neon
sentry:
    # Enabled only on production
    enable: true

    # Client configuration
    client:
        dsn: %sentry_dsn%
        integrations:
            - Contributte\Sentry\Integration\ExtraIntegration([
                version: %app_version%
            ])
```
It will get replaced by default integrations.
This changes the behavior to merge possibly existing integrations with default ones