### PR TITLE
Do not replace existing tags in NetteSessionIntegration

### DIFF
--- a/src/Integration/NetteSessionIntegration.php
+++ b/src/Integration/NetteSessionIntegration.php
@@ -54,9 +54,7 @@ class NetteSessionIntegration extends BaseIntegration
 		);
 
 		if (PHP_SAPI !== 'cli') {
-			$event->setTags([
-				$session->getName() => $session->getId(),
-			]);
+			$event->setTag($session->getName(), $session->getId());
 		}
 
 		return $event;


### PR DESCRIPTION
Currently application extensions cannot set tags because they are being overwritten immediately by builtin extension