### PR TITLE
Checking status of sessions before reading

### DIFF
--- a/src/Integration/NetteSecurityIntegration.php
+++ b/src/Integration/NetteSecurityIntegration.php
@@ -4,6 +4,7 @@ namespace Contributte\Sentry\Integration;
 
 use Nette\DI\Container;
 use Nette\Http\IRequest;
+use Nette\Http\Session;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\UserStorage;
 use Sentry\Event;
@@ -24,6 +25,18 @@ class NetteSecurityIntegration extends BaseIntegration
 
 		// There is no user storage
 		if (!$storage instanceof UserStorage) {
+			return $event;
+		}
+
+		$session = $this->context->getByType(Session::class, false);
+
+		// There is no session
+		if (!$session instanceof Session) {
+			return $event;
+		}
+
+		// Closed session
+		if (!$session->isStarted()) {
 			return $event;
 		}
 

--- a/src/Integration/NetteSessionIntegration.php
+++ b/src/Integration/NetteSessionIntegration.php
@@ -26,6 +26,11 @@ class NetteSessionIntegration extends BaseIntegration
 			return $event;
 		}
 
+		// Closed session
+		if (!$session->isStarted()) {
+			return $event;
+		}
+
 		// @see https://github.com/nette/http/blob/v3.1/src/Http/Session.php
 		// phpcs:ignore SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable.DisallowedSuperGlobalVariable
 		$sessionData = $_SESSION['__NF']['DATA'] ?? [];


### PR DESCRIPTION
If session is explicitly closed before sending to sentry, there is an error `Session cannot be started after headers have already been sent`.